### PR TITLE
Clean up auth client between auths

### DIFF
--- a/main/include/graph_client.h
+++ b/main/include/graph_client.h
@@ -6,6 +6,7 @@
 #include "esp_system.h"
 
 esp_err_t graph_client_init(QueueHandle_t *queue);
+esp_err_t refresh_token();
 
 #define PRESENCE_AVAILABLE 0U
 #define PRESENCE_BUSY 1U


### PR DESCRIPTION
Both to save some memory, as well as fix a bug where the socket is timed out, we clean out the auth client between auths (once every hour)