### PR TITLE
add fix for graph client exiting due to tls error

### DIFF
--- a/main/graph_client.c
+++ b/main/graph_client.c
@@ -208,7 +208,6 @@ static esp_err_t init_aad_auth_flow()
     ESP_LOGD(AUTH_CLIENT_TAG, "esp_http_client_read: complete");
     buffer[read_len] = 0;
     ESP_LOGD(AUTH_CLIENT_TAG, "read_len = %d", read_len);
-    // ESP_LOGI(AUTH_CLIENT_TAG, "read response: %s", buffer);
     
     // parse data
     cJSON *root = cJSON_Parse(buffer);

--- a/main/graph_client.c
+++ b/main/graph_client.c
@@ -262,6 +262,7 @@ static esp_err_t fetch_token(char *refresh_token)
         if(err != ESP_OK)
         {
             ESP_LOGE(AUTH_CLIENT_TAG, "could not set post field for token fetch");
+            free(data);
             return err;
         }
         ESP_LOGD(AUTH_CLIENT_TAG, "esp_http_client_set_post_field: complete");
@@ -271,13 +272,14 @@ static esp_err_t fetch_token(char *refresh_token)
         if((err = esp_http_client_perform(AUTH_CLIENT)) == ESP_ERR_HTTP_EAGAIN)
         {
             ESP_LOGI(AUTH_CLIENT_TAG, "perform return ESP_ERR_HTTP_EAGAIN, retrying again..");
+            free(data);
             continue;
         }
         if(err != ESP_OK)
         {
             ESP_LOGE(AUTH_CLIENT_TAG, "unable to execute method: %s", esp_err_to_name(err));
             free(data);
-            return err;
+            continue;
         }
         free(data);
         status_code = esp_http_client_get_status_code(AUTH_CLIENT);
@@ -537,7 +539,7 @@ void poll_presence_task(void *pvParameters)
                 break;
         } switchs_end
 
-        xQueueOverwrite(*evtQueueHandle, (void*) &presence);
+        xQueueSend(*evtQueueHandle, (void*) &presence, 0);
 
         cJSON_Delete(root);
         free(buffer);

--- a/main/include/ledcontrol.h
+++ b/main/include/ledcontrol.h
@@ -48,7 +48,7 @@ static struct led_color_t LED_COLOR_GREEN = {
 
 bool leds_init();
 void leds_clear();
-void led_color(int led_number, struct led_color_t color);
-void leds_color(struct led_color_t color);
+void led_color(int led_number, struct led_color_t *color);
+void leds_color(struct led_color_t *color);
 void leds_rainbow();
 void leds_apply(bool flash);

--- a/main/ledcontrol.c
+++ b/main/ledcontrol.c
@@ -106,7 +106,7 @@ void leds_clear()
     for (int i = 0; i < LED_STRIP_LENGTH; i++) {
         DESIRED_COLORS[i] = &LED_COLOR_OFF;
     }
-    led_strip_show(&led_strip);
+    leds_apply(false);
 }
 
 bool leds_init()
@@ -169,5 +169,8 @@ void leds_apply(bool flash)
             ESP_LOGE(TAG, "leds_apply: failed, retrying..");
             vTaskDelay(250 / portTICK_PERIOD_MS);
         }
+        
+        // add delay to give the leds a change to update
+        vTaskDelay(100 / portTICK_PERIOD_MS);
     }
 }

--- a/main/ledcontrol.c
+++ b/main/ledcontrol.c
@@ -64,23 +64,21 @@ static void leds_rainbow_task(void *pvParameters)
     }   
 }
 
-static void leds_helper_stop()
+static void leds_helper_stop_task()
 {
     if(led_task_handle != NULL) {
         vTaskDelete( led_task_handle );
         led_task_handle = NULL;
-        led_strip_clear(&led_strip);
     }
+    led_strip_clear(&led_strip);
 }
 
-void leds_helper_blink_task(void *pvParameters)
+void leds_blink_task(void *pvParameters)
 {
     for(;;)
     {
-        for (int i = 0; i < LED_STRIP_LENGTH; i++)
-        {
+        for (int i = 0; i < LED_STRIP_LENGTH; i++) {
             led_strip_set_pixel_color(&led_strip, i, &DESIRED_COLORS[i]);
-            ESP_LOGD(TAG, "led %d flashing R:%d G:%d B:%d\n", i, DESIRED_COLORS[i].red, DESIRED_COLORS[i].green, DESIRED_COLORS[i].blue);
         }
         led_strip_show(&led_strip);
         vTaskDelay(BLINK_INTERVAL / portTICK_PERIOD_MS);
@@ -93,7 +91,7 @@ void leds_helper_blink_task(void *pvParameters)
 
 void leds_clear()
 {
-    leds_helper_stop();
+    leds_helper_stop_task();
     led_strip_show(&led_strip);
 }
 
@@ -112,7 +110,7 @@ bool leds_init()
 
 void led_color(int led_index, struct led_color_t color)
 {
-    leds_helper_stop();
+    leds_helper_stop_task();
     if(led_index >= LED_STRIP_LENGTH) {
         ESP_LOGE(TAG, "tried to set led color for index %d, array only contains %d leds", led_index, LED_STRIP_LENGTH);
         return;
@@ -124,7 +122,7 @@ void led_color(int led_index, struct led_color_t color)
 
 void leds_color(struct led_color_t color)
 {
-    leds_helper_stop();
+    leds_helper_stop_task();
     for (int i = 0; i < LED_STRIP_LENGTH; i++)
     {
         DESIRED_COLORS[i] = color;
@@ -140,7 +138,7 @@ void leds_rainbow()
 void leds_apply(bool flash)
 {
     if(flash) {
-        xTaskCreate(leds_helper_blink_task, "leds_helper_blink_task", 2048, NULL, 5, &led_task_handle);
+        xTaskCreate(leds_blink_task, "leds_helper_blink_task", 2048, NULL, 5, &led_task_handle);
     } else {
         led_strip_show(&led_strip);
     }

--- a/main/main.c
+++ b/main/main.c
@@ -32,7 +32,7 @@ esp_err_t nvs_init()
 
 esp_err_t queue_init()
 {
-    evt_queue = xQueueCreate(1, sizeof(uint32_t));
+    evt_queue = xQueueCreate(2, sizeof(uint32_t));
     if(evt_queue != NULL) {
         return ESP_OK;
     } else {
@@ -50,33 +50,35 @@ void presence_handler_task(void *pvParameters)
     {
         if(xQueueReceive(*queue, &presence, portMAX_DELAY)) 
         {
+            bool presenceChanged = true;
             ESP_LOGD(TAG, "received presence event");
             if(presence == current) {
                 ESP_LOGD(TAG, "daddy status unchanged..");
-            } else if(presence == PRESENCE_AVAILABLE) {
-                ESP_LOGD(TAG, "daddy status: available");
-                current = presence;
-                leds_clear();
-                leds_color(LED_COLOR_GREEN);
-                leds_apply(false);
-            } else if(presence == PRESENCE_BUSY) {
-                ESP_LOGD(TAG, "daddy status: busy");
-                current = presence;
-                leds_clear();
-                led_color(0, LED_COLOR_YELLOW);
-                led_color(1, LED_COLOR_OFF);
-                leds_apply(false);
-            } else if(presence == PRESENCE_OFF_WORK) {
-                ESP_LOGD(TAG, "Daddy status: play time");
-                current = presence;
-                leds_clear();
-                leds_rainbow();
-            } else { //if(presence == PRESENCE_DO_NOT_DISTURB)
-                ESP_LOGD(TAG, "daddy status: DND");
-                current = presence;
-                leds_clear();
-                leds_color(LED_COLOR_RED);
-                leds_apply(true);
+            } else if(presence != current) {
+                leds_clear();                
+                ESP_LOGD(TAG, "daddy status changed..");
+
+                if(presence == PRESENCE_OFF_WORK) {
+                    ESP_LOGD(TAG, "Daddy status: play time");
+                    current = presence;
+                    leds_rainbow();
+                } else if(presence == PRESENCE_DO_NOT_DISTURB) {
+                    ESP_LOGD(TAG, "daddy status: DND");
+                    current = presence;
+                    leds_color(&LED_COLOR_RED);
+                    leds_apply(true);
+                } else if(presence == PRESENCE_AVAILABLE) {
+                    ESP_LOGD(TAG, "daddy status: available");
+                    current = presence;
+                    leds_color(&LED_COLOR_GREEN);
+                    leds_apply(false);
+                } else if(presence == PRESENCE_BUSY) {
+                    ESP_LOGD(TAG, "daddy status: busy");
+                    current = presence;
+                    led_color(0, &LED_COLOR_YELLOW);
+                    led_color(1, &LED_COLOR_OFF);
+                    leds_apply(false);
+                }
             }
         }
     }

--- a/main/main.c
+++ b/main/main.c
@@ -45,7 +45,7 @@ void presence_handler_task(void *pvParameters)
     QueueHandle_t *queue = pvParameters;
 
     ESP_LOGI(TAG, "Retrieve task started..");
-    unsigned int presence;
+    unsigned int presence = 1000;
     for(;;) 
     {
         if(xQueueReceive(*queue, &presence, portMAX_DELAY)) 
@@ -56,21 +56,25 @@ void presence_handler_task(void *pvParameters)
             } else if(presence == PRESENCE_AVAILABLE) {
                 ESP_LOGD(TAG, "daddy status: available");
                 current = presence;
+                leds_clear();
                 leds_color(LED_COLOR_GREEN);
                 leds_apply(false);
             } else if(presence == PRESENCE_BUSY) {
                 ESP_LOGD(TAG, "daddy status: busy");
                 current = presence;
+                leds_clear();
                 led_color(0, LED_COLOR_YELLOW);
                 led_color(1, LED_COLOR_OFF);
                 leds_apply(false);
             } else if(presence == PRESENCE_OFF_WORK) {
                 ESP_LOGD(TAG, "Daddy status: play time");
                 current = presence;
+                leds_clear();
                 leds_rainbow();
             } else { //if(presence == PRESENCE_DO_NOT_DISTURB)
                 ESP_LOGD(TAG, "daddy status: DND");
                 current = presence;
+                leds_clear();
                 leds_color(LED_COLOR_RED);
                 leds_apply(true);
             }


### PR DESCRIPTION
The graph api was causing the graph client to panic due to tls errors.
Will do a re-init of the client if 5 concurrent retries have failed.