### PR TITLE
Fix issue with switching between background tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,11 @@
     "type_traits": "cpp",
     "utility": "cpp",
     "gpio.h": "c"
-  }
+  },
+  "idf.adapterTargetName": "esp32",
+  "idf.port": "/dev/ttyUSB0",
+  "idf.baudRate": "115200",
+  "idf.openOcdConfigs": [
+    "board/esp32-wrover.cfg"
+  ]
 }

--- a/main/include/graph_client.h
+++ b/main/include/graph_client.h
@@ -12,5 +12,8 @@ esp_err_t refresh_token();
 #define PRESENCE_BUSY 1U
 #define PRESENCE_DO_NOT_DISTURB 2U
 #define PRESENCE_OFF_WORK 3U
+#define STATE_TOKEN_REFRESH 4U
+#define STATE_TOKEN_RECEIVED 5U
+#define STATE_FAILED 6U
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -58,7 +58,17 @@ void presence_handler_task(void *pvParameters)
                 leds_clear();                
                 ESP_LOGD(TAG, "daddy status changed..");
 
-                if(presence == PRESENCE_OFF_WORK) {
+                if(presence == STATE_TOKEN_REFRESH) {
+                    ESP_LOGD(TAG, "Refreshing token");
+                    current = presence;
+                    leds_color(&LED_COLOR_YELLOW);
+                    leds_apply(true);
+                } else if(presence == STATE_TOKEN_RECEIVED) {
+                    ESP_LOGD(TAG, "Token received, fetching presence");
+                    current = presence;
+                    leds_color(&LED_COLOR_GREEN);
+                    leds_apply(true);
+                } else if(presence == PRESENCE_OFF_WORK) {
                     ESP_LOGD(TAG, "Daddy status: play time");
                     current = presence;
                     leds_rainbow();


### PR DESCRIPTION
- use a copy of the task reference pointer when deleting background task.
- add a few more visual states to know what's going on (fetching token, fetching presence)

Previously you could end up in a bad state when switching from one background task to another.